### PR TITLE
[STEP18] 결제 완료 로직에 Outbox Pattern 적용

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -151,3 +151,20 @@ model product {
   order_detail       order_detail[]
   product_sales_stat product_sales_stat[]
 }
+
+model outbox {
+  id         Int           @id @default(autoincrement())
+  topic      String        @db.VarChar(255)
+  key        String?       @db.VarChar(255)
+  message    String        @db.Text
+  status     outbox_status @default(INIT)
+  updated_at DateTime      @default(now()) @db.DateTime(0)
+  created_at DateTime      @default(now()) @db.DateTime(0)
+
+  @@index([status], map: "idx_status")
+}
+
+enum outbox_status {
+  INIT
+  PUBLISHED
+}

--- a/src/configs/configs.service.ts
+++ b/src/configs/configs.service.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ConfigModuleOptions } from '@nestjs/config';
 import * as Joi from 'joi';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { ConfigService } from '@nestjs/config';
 
 @Module({})
 export class AppConfigService {
@@ -18,6 +20,24 @@ export class AppConfigService {
                 REDIS_HOST: Joi.string().default('localhost'),
                 REDIS_PORT: Joi.number().default(6379),
             }),
+        };
+    }
+
+    static getKafkaConfigs(configService: ConfigService): MicroserviceOptions {
+        return {
+            transport: Transport.KAFKA,
+            options: {
+                client: {
+                    clientId: 'commerce-server',
+                    brokers: configService.get<string>('KAFKA_BROKER').split(','),
+                },
+                consumer: {
+                    groupId: 'commerce-group',
+                },
+                producer: {
+                    allowAutoTopicCreation: true,
+                },
+            },
         };
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,16 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { PrismaExceptionFilter } from './common/filters/prisma-exception.filter';
+import { MicroserviceOptions } from '@nestjs/microservices';
+import { AppConfigService } from './configs/configs.service';
+import { ConfigService } from '@nestjs/config';
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
+
+    const configService = app.get(ConfigService);
+
+    app.connectMicroservice<MicroserviceOptions>(AppConfigService.getKafkaConfigs(configService));
+    await app.startAllMicroservices();
 
     // 전역 필터 설정
     app.useGlobalFilters(new HttpExceptionFilter(), new PrismaExceptionFilter());

--- a/src/outbox/domain/outbox.repository.interface.ts
+++ b/src/outbox/domain/outbox.repository.interface.ts
@@ -1,0 +1,11 @@
+import { outbox as PrismaOutbox } from '@prisma/client';
+
+export interface IOutboxRepository {
+    createOutbox(
+        outbox: Omit<PrismaOutbox, 'id' | 'created_at' | 'status' | 'updated_at'>,
+    ): Promise<PrismaOutbox>;
+    findOutboxInitStatus(): Promise<PrismaOutbox[]>;
+    updateOutboxStatus(key: string, status: string): Promise<PrismaOutbox>;
+}
+
+export const IOUTBOX_REPOSITORY = Symbol('IOUTBOX_REPOSITORY');

--- a/src/outbox/domain/service/outbox.service.it.spec.ts
+++ b/src/outbox/domain/service/outbox.service.it.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OutboxModule } from '../../outbox.module';
+import { PrismaModule } from '../../../database/prisma.module';
+import { WinstonModule } from 'nest-winston';
+import { winstonConfig } from '../../../configs/winston.config';
+import { OutboxService } from './outbox.service';
+describe('OutboxService', () => {
+    let service: OutboxService;
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            imports: [OutboxModule, PrismaModule, WinstonModule.forRoot(winstonConfig)],
+        }).compile();
+
+        service = module.get<OutboxService>(OutboxService);
+    });
+
+    describe('createOutbox: outbox 생성 테스트', () => {
+        describe('성공 케이스', () => {
+            it('정상적인 outbox 데이터가 주어지면 outbox를 생성한다', async () => {
+                // given
+                const outboxData = {
+                    topic: 'test-topic',
+                    key: 'test-key',
+                    message: 'test-message',
+                };
+
+                // when
+                const result = await service.createOutbox({
+                    topic: outboxData.topic,
+                    key: outboxData.key,
+                    message: outboxData.message,
+                });
+
+                // then
+                expect(result.topic).toEqual(outboxData.topic);
+                expect(result.key).toEqual(outboxData.key);
+                expect(result.message).toEqual(outboxData.message);
+            });
+        });
+    });
+
+    describe('findOutboxInitStatus: outbox 조회 테스트', () => {
+        it('init 상태의 outbox를 조회한다', async () => {
+            // given
+            const outboxData = {
+                topic: 'test-topic',
+                key: 'test-key2',
+                message: 'test-message2',
+            };
+
+            await service.createOutbox(outboxData);
+
+            // when
+            const result = await service.findOutboxInitStatus();
+
+            // then
+            expect(result.length).toEqual(2);
+            expect(result[0].status).toEqual('INIT');
+            expect(result[1].status).toEqual('INIT');
+        });
+    });
+
+    describe('updateOutboxStatus: outbox 상태 업데이트 테스트', () => {
+        it('outbox 상태를 업데이트한다', async () => {
+            // given
+            const outboxDatas = await service.findOutboxInitStatus();
+
+            // when
+            const result = await service.updateOutboxStatus(outboxDatas[0].key, 'PUBLISHED');
+
+            // then
+            expect(result.status).toEqual('PUBLISHED');
+        });
+    });
+});

--- a/src/outbox/domain/service/outbox.service.ts
+++ b/src/outbox/domain/service/outbox.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IOutboxRepository } from '../outbox.repository.interface';
+import { outbox as PrismaOutbox } from '@prisma/client';
+import { IOUTBOX_REPOSITORY } from '../outbox.repository.interface';
+import { LoggerUtil } from '../../../common/utils/logger.util';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { InternalServerErrorException } from '@nestjs/common';
+@Injectable()
+export class OutboxService {
+    constructor(
+        @Inject(IOUTBOX_REPOSITORY)
+        private readonly outboxRepository: IOutboxRepository,
+    ) {}
+
+    // outbox 생성
+    async createOutbox(
+        outbox: Omit<PrismaOutbox, 'id' | 'created_at' | 'status' | 'updated_at'>,
+    ): Promise<PrismaOutbox> {
+        try {
+            return this.outboxRepository.createOutbox(outbox);
+        } catch (error) {
+            LoggerUtil.error('outbox 생성 오류', error, outbox);
+            if (error instanceof PrismaClientKnownRequestError) {
+                throw error;
+            }
+            throw new InternalServerErrorException('outbox 생성 중 오류가 발생했습니다.');
+        }
+    }
+
+    // init 상태의 outbox 조회
+    async findOutboxInitStatus(): Promise<PrismaOutbox[]> {
+        try {
+            return this.outboxRepository.findOutboxInitStatus();
+        } catch (error) {
+            LoggerUtil.error('outbox 조회 오류', error, {});
+            if (error instanceof PrismaClientKnownRequestError) {
+                throw error;
+            }
+            throw new InternalServerErrorException('outbox 조회 중 오류가 발생했습니다.');
+        }
+    }
+
+    // outbox 상태 업데이트
+    async updateOutboxStatus(key: string, status: string): Promise<PrismaOutbox> {
+        try {
+            return this.outboxRepository.updateOutboxStatus(key, status);
+        } catch (error) {
+            LoggerUtil.error('outbox 상태 업데이트 오류', error, { key, status });
+            if (error instanceof PrismaClientKnownRequestError) {
+                throw error;
+            }
+            throw new InternalServerErrorException('outbox 상태 업데이트 중 오류가 발생했습니다.');
+        }
+    }
+}

--- a/src/outbox/infrastructure/outbox.repository.mysql.impl.ts
+++ b/src/outbox/infrastructure/outbox.repository.mysql.impl.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../database/prisma.service';
+import { outbox as PrismaOutbox, Prisma } from '@prisma/client';
+import { getClient } from '../../common/util';
+import { IOutboxRepository } from '../domain/outbox.repository.interface';
+@Injectable()
+export class OutboxRepository implements IOutboxRepository {
+    constructor(private readonly prisma: PrismaService) {}
+
+    async createOutbox(
+        outbox: Omit<PrismaOutbox, 'id' | 'created_at' | 'status' | 'updated_at'>,
+    ): Promise<PrismaOutbox> {
+        const client = getClient(this.prisma);
+        return await client.outbox.create({
+            data: outbox,
+        });
+    }
+
+    async findOutboxInitStatus(): Promise<PrismaOutbox[]> {
+        const client = getClient(this.prisma);
+        const outbox = await client.outbox.findMany({
+            where: {
+                status: 'INIT',
+            },
+        });
+        return outbox;
+    }
+
+    async updateOutboxStatus(key: string, status: string): Promise<PrismaOutbox> {
+        const client = getClient(this.prisma);
+
+        const outbox = await client.outbox.findFirst({
+            where: { key },
+        });
+
+        return await client.outbox.update({
+            where: { id: outbox.id },
+            data: { status: status as PrismaOutbox['status'] },
+        });
+    }
+}

--- a/src/outbox/infrastructure/outbox.repository.mysql.impl.ts
+++ b/src/outbox/infrastructure/outbox.repository.mysql.impl.ts
@@ -18,9 +18,15 @@ export class OutboxRepository implements IOutboxRepository {
 
     async findOutboxInitStatus(): Promise<PrismaOutbox[]> {
         const client = getClient(this.prisma);
+
+        const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+
         const outbox = await client.outbox.findMany({
             where: {
                 status: 'INIT',
+                created_at: {
+                    lte: fiveMinutesAgo,
+                },
             },
         });
         return outbox;

--- a/src/outbox/outbox.module.ts
+++ b/src/outbox/outbox.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { OutboxService } from './domain/service/outbox.service';
+import { OutboxRepository } from './infrastructure/outbox.repository.mysql.impl';
+import { IOUTBOX_REPOSITORY } from './domain/outbox.repository.interface';
+import { PrismaModule } from '../database/prisma.module';
+
+@Module({
+    imports: [PrismaModule],
+    controllers: [],
+    providers: [
+        OutboxService,
+        {
+            provide: IOUTBOX_REPOSITORY,
+            useClass: OutboxRepository,
+        },
+    ],
+    exports: [OutboxService],
+})
+export class OutboxModule {}

--- a/src/payment/application/payment.facade.ts
+++ b/src/payment/application/payment.facade.ts
@@ -174,7 +174,7 @@ export class PaymentFacade {
                 });
 
                 // 결제 완료 이벤트 발행
-                this.eventBus.publish(new CompleteCreatePaymentEvent(result.id));
+                this.eventBus.publish(new CompleteCreatePaymentEvent(result.id, result.order_id));
                 return result;
             } catch (error) {
                 LoggerUtil.error('결제 생성 오류', error, { dto });

--- a/src/payment/event/complete-create-payment.event.ts
+++ b/src/payment/event/complete-create-payment.event.ts
@@ -1,3 +1,6 @@
 export class CompleteCreatePaymentEvent {
-    constructor(public readonly paymentId: number) {}
+    constructor(
+        public readonly paymentId: number,
+        public readonly orderId: number,
+    ) {}
 }

--- a/src/payment/event/complete-create-payment.handler.ts
+++ b/src/payment/event/complete-create-payment.handler.ts
@@ -1,11 +1,37 @@
 import { CompleteCreatePaymentEvent } from './complete-create-payment.event';
 import { FakeDataPlatform } from '../../common/fakeDataplatform';
 import { IEventHandler, EventsHandler } from '@nestjs/cqrs';
+// import { KafkaPublisherService } from '../../kafka/domain/service/kafka-publisher.service';
+import { OutboxService } from '../../outbox/domain/service/outbox.service';
+import { ClientKafka } from '@nestjs/microservices';
+import { Inject } from '@nestjs/common';
+import { log } from 'console';
 
 @EventsHandler(CompleteCreatePaymentEvent)
 export class CompleteCreatePaymentHandler implements IEventHandler<CompleteCreatePaymentEvent> {
+    constructor(
+        // private readonly publisher: KafkaPublisherService,
+        @Inject('KAFKA_CLIENT') private readonly client: ClientKafka,
+        private readonly outboxService: OutboxService,
+    ) {}
     async handle(event: CompleteCreatePaymentEvent) {
-        const fakeDataPlatform = new FakeDataPlatform();
-        fakeDataPlatform.send();
+        // outbox row 생성
+        await this.outboxService.createOutbox({
+            topic: 'payment-created',
+            key: event.paymentId.toString(),
+            message: JSON.stringify({
+                paymentId: event.paymentId,
+                orderId: event.orderId,
+            }),
+        });
+
+        // 카프카 메시지 발행
+        this.client.emit('payment-created', {
+            key: event.paymentId.toString(),
+            value: JSON.stringify({
+                paymentId: event.paymentId,
+                orderId: event.orderId,
+            }),
+        });
     }
 }

--- a/src/payment/infrastructure/payment.repository.mysql.impl.ts
+++ b/src/payment/infrastructure/payment.repository.mysql.impl.ts
@@ -3,8 +3,6 @@ import { PrismaService } from '../../database/prisma.service';
 import { IPaymentRepository } from '../domain/payment.repository.interface';
 import { payment as PrismaPayment, Prisma } from '@prisma/client';
 import { getClient } from '../../common/util';
-import { NotFoundException, InternalServerErrorException } from '@nestjs/common';
-import { LoggerUtil } from '../../common/utils/logger.util';
 @Injectable()
 export class PaymentRepository implements IPaymentRepository {
     constructor(private readonly prisma: PrismaService) {}

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -57,6 +57,7 @@ const modules = [UserModule, ProductModule, CouponModule, OrderModule, HistoryMo
         PaymentFacade,
         { provide: IPAYMENT_REPOSITORY, useClass: PaymentRepository },
         CompleteCreatePaymentHandler,
+        OutboxScheduler,
     ],
     exports: [PaymentService, PaymentFacade],
 })

--- a/src/payment/presentation/complete-create-payment.consumer.ts
+++ b/src/payment/presentation/complete-create-payment.consumer.ts
@@ -1,0 +1,32 @@
+// src/payment/event/complete-create-payment.consumer.ts
+import { Controller, OnModuleInit } from '@nestjs/common';
+import { ClientKafka, MessagePattern, Payload } from '@nestjs/microservices';
+import { OutboxService } from '../../outbox/domain/service/outbox.service';
+import { Inject } from '@nestjs/common';
+import { FakeDataPlatform } from '../../common/fakeDataplatform';
+
+@Controller()
+export class CompleteCreatePaymentConsumer implements OnModuleInit {
+    constructor(
+        @Inject('KAFKA_CLIENT') private readonly kafkaClient: ClientKafka,
+        private readonly outboxService: OutboxService,
+    ) {}
+
+    async onModuleInit() {
+        await this.kafkaClient.connect();
+    }
+
+    @MessagePattern('payment-created')
+    async handlePaymentCreated(@Payload() message: any) {
+        // value가 문자열인 경우를 대비해 파싱 처리
+        const value = typeof message.value === 'string' ? JSON.parse(message) : message;
+        const { paymentId } = value;
+
+        // 아웃박스 상태 업데이트
+        await this.outboxService.updateOutboxStatus(paymentId.toString(), 'PUBLISHED');
+
+        // 데이터 플랫폼 전송
+        const fakeDataPlatform = new FakeDataPlatform();
+        fakeDataPlatform.send();
+    }
+}

--- a/src/payment/presentation/outbox.scheduler.ts
+++ b/src/payment/presentation/outbox.scheduler.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { OutboxService } from '../../outbox/domain/service/outbox.service';
+import { ClientKafka } from '@nestjs/microservices';
+import { Inject } from '@nestjs/common';
+
+@Injectable()
+export class OutboxScheduler {
+    constructor(
+        @Inject('KAFKA_CLIENT') private readonly client: ClientKafka,
+        private readonly outboxService: OutboxService,
+    ) {}
+
+    @Cron('0 */5 * * * *')
+    async handleOutbox() {
+        const initOutboxList = await this.outboxService.findOutboxInitStatus();
+
+        for (const outbox of initOutboxList) {
+            // 카프카 토픽 발행
+            this.client.emit(outbox.topic, outbox.message);
+
+            // 아웃박스 상태 업데이트
+            await this.outboxService.updateOutboxStatus(outbox.key, 'PUBLISHED');
+        }
+    }
+}

--- a/test/it/table.init.sql
+++ b/test/it/table.init.sql
@@ -98,6 +98,18 @@ CREATE TABLE `payment` (
   `created_at` datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 );
 
+CREATE TABLE `outbox` (
+  `id` int PRIMARY KEY AUTO_INCREMENT,
+  `topic` varchar(255) NOT NULL,
+  `key` varchar(255) DEFAULT NULL,
+  `message` text NOT NULL,
+  `status` ENUM('INIT', 'PUBLISHED') NOT NULL DEFAULT 'INIT',
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX `idx_status` ON `outbox` (`status`);
+
 CREATE UNIQUE INDEX `product_sales_stat_index_0` ON `product_sales_stat` (`product_id`, `date`);
 
 CREATE INDEX `product_sales_stat_index_1` ON `product_sales_stat` (`date`);


### PR DESCRIPTION
## 📌 PR 유형

<!-- 어떠한 변경 사항이 있는지 [x]로 체크 -->

-   [ ] 버그 수정
-   [x] 새로운 기능(테스트) 추가
-   [x] 코드 리팩토링 및 기능 개선
-   [ ] 의존성, 문서, 빌드 관련 코드 업데이트
-   [ ] 기능(테스트) 삭제
-   [ ] 기타 (내용을 적어주세요):

---

## 🗒️ PR 설명

### 개요

-   결제 완료 로직에 Outbox Pattern 적용

### 변경 사항

-   카프카를 적용하여 결제 완료 로직에 Outbox Pattern 적용
-   카프카 메시지 발행이 실패한 케이스에 대한 재처리 스케줄러 추가 (5분 간격)

---

## **🔗 커밋 링크**

-   outbox 모듈 추가: 65f29fc
-   결제 완료 이벤트 핸들러 수정 및 payment 모듈 카프카 적용: d3a3958
-   결제 완료 kafka 컨슈머 추가: 0ad18e0
-   카프카 메시지 발행 실패 시, 재처리 스케줄러 추가: 66634c8
-   스케줄러 수정 (카프카 발행이 5분 이상된 경우만 재처리) : 7e59402

---

## **🙋‍♂️ 리뷰 포인트(질문)**

-   리뷰 포인트 1

    -   outbox 테이블 스키마의 정보가 충분한지 궁금합니다. 혹여나 실무에서 필요한 필드가 빠졌다던지 하는 것들이 있는지 궁금합니다.

        ```sql
        CREATE TABLE `outbox` (
            `id` int PRIMARY KEY AUTO_INCREMENT,
            `topic` varchar(255) NOT NULL,
            `key` varchar(255) DEFAULT NULL,
            `message` text NOT NULL,
            `status` ENUM('INIT', 'PUBLISHED') NOT NULL DEFAULT 'INIT',
            `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
            `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
        );
        ```

---

## **🤔 이번주 KPT 회고**

### Keep

-   카프카 컨슈머가 적용이 되지 않아, 어떻게든 원인을 찾아서 해결한 것.

### Problem

-   선착순 쿠폰 발행까지 적용해보려고 했으나, 시간 부족으로 인해 적용하지 못했음... 흑흑...

### Try

-   선착순 쿠폰 발행 로직에도 적용
-   카프카 옵션들 자세히 공부
-   카프카 클러스터링시, 각 브로커들의 역할 공부

---
